### PR TITLE
chore: add URL scheme validation, pin Go 1.22 in CI, and enhance linter rules

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.22'
 
       - name: Generate OpenAPI Go client
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.18'
+          go-version: '1.22'
 
       - name: Run Tests
         run: go test ./... -v

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,6 +11,8 @@ linters:
     - gosimple
     - ineffassign
     - typecheck
+    - bodyclose
+    - gosec
 
 issues:
   exclude-dirs:
@@ -27,3 +29,5 @@ issues:
         - staticcheck
         - typecheck
         - unused
+        - bodyclose
+        - gosec

--- a/README.md
+++ b/README.md
@@ -217,9 +217,13 @@ func main() {
 	jobID := "72c037df-d0d3-43ee-9470-323ff35a2e50"
 	downloadURL := fmt.Sprintf("https://api.xyo.financial/ai/transactions/download/%s.tar.gz", jobID)
 
-	ctx := context.Background()
+	// Poll with timeout and exponential backoff
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
 
-	// Poll until ready or failed with backoff
+	backoff := 2 * time.Second
+	maxBackoff := 15 * time.Second
+
 	for {
 		status, err := client.GetEnrichmentStatus(ctx, jobID)
 		if err != nil {
@@ -235,7 +239,17 @@ func main() {
 			log.Fatalf("bulk enrichment job %s failed processing on server", jobID)
 		}
 
-		time.Sleep(3 * time.Second)
+		select {
+		case <-ctx.Done():
+			log.Fatalf("timed out waiting for bulk enrichment: %v", ctx.Err())
+		case <-time.After(backoff):
+			if backoff < maxBackoff {
+				backoff *= 2
+				if backoff > maxBackoff {
+					backoff = maxBackoff
+				}
+			}
+		}
 	}
 
 	// Stream and decompress results on-the-fly

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -11,7 +11,7 @@ ENV CGO_ENABLED=0
 RUN apk add --update-cache \
     curl
 
-RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.59.1 \
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/v1.59.1/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.59.1 \
     && golangci-lint --version
 
 # Linting (includes gofmt & govet via .golangci.yml) and Tests

--- a/enrichment.go
+++ b/enrichment.go
@@ -88,6 +88,9 @@ func (c *client) EnrichTransaction(ctx context.Context, req *EnrichmentRequest) 
 
 	genReq := openapi.NewEnrichmentRequest(req.Content, req.CountryCode)
 	resp, httpResp, err := c.apiClient.EnrichmentAPI.EnrichTransaction(ctx).EnrichmentRequest(*genReq).Execute()
+	if httpResp != nil && httpResp.Body != nil {
+		defer func() { _ = httpResp.Body.Close() }()
+	}
 	if err != nil {
 		return nil, parseOpenAPIError(err, "EnrichTransaction", httpResp)
 	}
@@ -117,6 +120,9 @@ func (c *client) EnrichTransactions(ctx context.Context, reqs []*EnrichmentReque
 
 	resp, httpResp, err := c.apiClient.EnrichmentAPI.EnrichTransactions(ctx).
 		EnrichTransactionsRequestInner(items).Execute()
+	if httpResp != nil && httpResp.Body != nil {
+		defer func() { _ = httpResp.Body.Close() }()
+	}
 	if err != nil {
 		return nil, parseOpenAPIError(err, "EnrichTransactions", httpResp)
 	}
@@ -143,6 +149,9 @@ func (c *client) GetEnrichmentStatus(ctx context.Context, id string) (Enrichment
 	}
 
 	resp, httpResp, err := c.apiClient.EnrichmentAPI.GetEnrichmentStatus(ctx, id).Execute()
+	if httpResp != nil && httpResp.Body != nil {
+		defer func() { _ = httpResp.Body.Close() }()
+	}
 	if err != nil {
 		return "", parseOpenAPIError(err, "GetEnrichmentStatus", httpResp)
 	}

--- a/enrichment.go
+++ b/enrichment.go
@@ -169,6 +169,14 @@ func (c *client) DownloadEnrichmentCollection(ctx context.Context, downloadURL s
 		return nil, fmt.Errorf("xyo: DownloadEnrichmentCollection: downloadURL cannot be empty")
 	}
 
+	parsedDownloadURL, err := url.Parse(downloadURL)
+	if err != nil {
+		return nil, fmt.Errorf("xyo: DownloadEnrichmentCollection: parse downloadURL: %w", err)
+	}
+	if parsedDownloadURL.Scheme != "http" && parsedDownloadURL.Scheme != "https" {
+		return nil, fmt.Errorf("xyo: DownloadEnrichmentCollection: invalid URL scheme %q (only http and https are permitted)", parsedDownloadURL.Scheme)
+	}
+
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, downloadURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("xyo: DownloadEnrichmentCollection: build request: %w", err)
@@ -179,8 +187,7 @@ func (c *client) DownloadEnrichmentCollection(ctx context.Context, downloadURL s
 	}
 
 	// Only attach Authorization header if download URL matches the configured API host
-	parsedDownloadURL, parseDownloadErr := url.Parse(downloadURL)
-	if parseDownloadErr == nil && parsedDownloadURL.Host != "" {
+	if parsedDownloadURL.Host != "" {
 		parsedBaseURL, parseBaseErr := url.Parse(c.apiBaseURL)
 		if parseBaseErr == nil && parsedBaseURL.Host != "" {
 			if strings.EqualFold(parsedDownloadURL.Host, parsedBaseURL.Host) {

--- a/enrichment_test.go
+++ b/enrichment_test.go
@@ -39,6 +39,7 @@ func newTestServerAndClient(t *testing.T, expectedMethod, expectedPath string, s
 			_ = json.NewEncoder(w).Encode(responsePayload)
 		}
 	}))
+	t.Cleanup(ts.Close)
 
 	client, err := NewClient(&ClientConfig{
 		APIKey:  "test-api-key",
@@ -431,5 +432,30 @@ func TestVersionConstants(t *testing.T) {
 	}
 	if DefaultUserAgent != "xyo-sdk-go/"+Version {
 		t.Errorf("expected DefaultUserAgent 'xyo-sdk-go/%s', got %q", Version, DefaultUserAgent)
+	}
+}
+
+func TestDownloadEnrichmentCollection_InvalidScheme(t *testing.T) {
+	client, err := NewClient(&ClientConfig{
+		APIKey: "test-api-key",
+	})
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+
+	invalidURLs := []string{
+		"file:///etc/passwd",
+		"ftp://example.com/file.tar.gz",
+		"gopher://example.com",
+		"javascript:alert(1)",
+	}
+
+	for _, u := range invalidURLs {
+		t.Run(u, func(t *testing.T) {
+			_, err := client.DownloadEnrichmentCollection(context.Background(), u)
+			if err == nil {
+				t.Fatalf("expected error for invalid scheme %q, got nil", u)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

This PR addresses the security hardening and CI/CD consistency items from the follow-up review:

### 🔒 Security & Robustness
- **URL Scheme Validation (C1)**: Enforced strict `http` / `https` scheme validation in `DownloadEnrichmentCollection` to prevent unsupported/arbitrary scheme abuse while maintaining compatibility with presigned object store URLs.
- **Dockerfile Supply-Chain Pin (C4)**: Pinned the `golangci-lint` installation script to the `v1.59.1` release tag instead of unpinned `HEAD`.

### ⚙️ CI/CD & Pipeline Consistency
- **Go 1.22 Synchronization (C2)**: Updated `.github/workflows/release.yml` and `.github/workflows/generate.yml` to pin `go-version: '1.22'` in alignment with `go.mod`.

### 🛠 Quality & Testing
- **Linters (S5)**: Added `gosec` and `bodyclose` to `.golangci.yml`.
- **Test Server Cleanup (S4)**: Added `t.Cleanup(ts.Close)` to test helper server setup to eliminate port/resource leaks.
- **Documentation (S10)**: Enhanced the polling snippet in `README.md` to demonstrate context cancellation and exponential backoff.
- **Unit Tests**: Added test cases verifying scheme rejection on invalid protocol schemes (`file://`, `ftp://`, etc.).