### PR TITLE
chore: enterprise security hardening, forward compatibility, and v2 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0] - 2026-08-15
+### Added
+- Migrated module path to `github.com/xyo-financial/sdk-go/v2`.
+- Full OpenAPI-driven client architecture with strongly-typed interfaces.
+- Structured RFC 7807 problem details error handling via `ErrorResponse` and `APIError`, supporting `errors.As` unwrapping.
+- In-memory streaming tarball decompression for bulk collection downloads (`DownloadEnrichmentCollection`).
+- Decompression bomb mitigations: aggregate stream byte bounds (`DefaultMaxArchiveBytes = 100MiB`), per-entry size limits (`DefaultMaxEntryBytes = 10MiB`), and entry count bounds (`DefaultMaxTarEntries = 50,000`).
+- Strict URL scheme validation (`http`/`https`) for bulk download endpoints.
+- Authorization header cross-host leak prevention on downloads.
+- Automatic secret token redaction in OpenAPI client debug logging (`Authorization`, `Proxy-Authorization`, `Cookie`).
+- Bounded response body reading across all OpenAPI endpoints (`maxResponseBytes = 32MiB`).
+- Dedicated SDK version constants in `version.go` (`Version`, `DefaultUserAgent`).
+- Modern Go 1.22 minimum toolchain support across `go.mod`, CI workflows, Docker, and examples.
+
+### Changed
+- Removed `decoder.DisallowUnknownFields()` across models to guarantee forward-compatible JSON decoding for API additive schema updates.
+- Upgraded CI pipelines to Go 1.22 with SLSA attestations and SBOM generation.
+- Expanded static analysis suite with `gosec` and `bodyclose` linters.
+- Enhanced polling example documentation with exponential backoff and `context.WithTimeout` deadline cancellation.
+
 ## [1.2.4] - 2026-08-07
 ### Changed
 - Updated repository URL and module path to `github.com/xyo-financial/sdk-go`.

--- a/enrichment_test.go
+++ b/enrichment_test.go
@@ -459,3 +459,30 @@ func TestDownloadEnrichmentCollection_InvalidScheme(t *testing.T) {
 		})
 	}
 }
+
+func TestEnrichTransaction_ForwardCompatibilityUnknownFields(t *testing.T) {
+	// Simulate the backend adding new unknown fields in a future API release
+	payload := map[string]interface{}{
+		"merchant":               "Syniol Limited",
+		"description":            "Software Consultancy",
+		"categories":             []string{"Tech"},
+		"logo":                   "base64/png",
+		"location":               "London, UK",
+		"address":                "123 Street",
+		"future_additive_field":  "should_not_break",
+		"another_additive_field": 999,
+	}
+
+	_, client := newTestServerAndClient(t, http.MethodPost, "/v1/ai/finance/enrichment/transaction", http.StatusOK, payload)
+
+	resp, err := client.EnrichTransaction(context.Background(), &EnrichmentRequest{
+		Content:     "Syniol Test",
+		CountryCode: "GB",
+	})
+	if err != nil {
+		t.Fatalf("expected decode to succeed with unknown fields, got error: %v", err)
+	}
+	if resp.Merchant != "Syniol Limited" {
+		t.Errorf("expected merchant %q, got %q", "Syniol Limited", resp.Merchant)
+	}
+}

--- a/openapi/api_enrichment.go
+++ b/openapi/api_enrichment.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 )
 
+const maxResponseBytes = 32 * 1024 * 1024 // 32 MiB response read limit
 
 // EnrichmentAPIService EnrichmentAPI service
 type EnrichmentAPIService service
@@ -103,7 +104,7 @@ func (a *EnrichmentAPIService) EnrichTransactionExecute(r ApiEnrichTransactionRe
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
-	localVarBody, err := io.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := io.ReadAll(io.LimitReader(localVarHTTPResponse.Body, maxResponseBytes))
 	localVarHTTPResponse.Body.Close()
 	localVarHTTPResponse.Body = io.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
@@ -240,7 +241,7 @@ func (a *EnrichmentAPIService) EnrichTransactionsExecute(r ApiEnrichTransactions
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
-	localVarBody, err := io.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := io.ReadAll(io.LimitReader(localVarHTTPResponse.Body, maxResponseBytes))
 	localVarHTTPResponse.Body.Close()
 	localVarHTTPResponse.Body = io.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
@@ -373,7 +374,7 @@ func (a *EnrichmentAPIService) GetEnrichmentStatusExecute(r ApiGetEnrichmentStat
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
-	localVarBody, err := io.ReadAll(localVarHTTPResponse.Body)
+	localVarBody, err := io.ReadAll(io.LimitReader(localVarHTTPResponse.Body, maxResponseBytes))
 	localVarHTTPResponse.Body.Close()
 	localVarHTTPResponse.Body = io.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {

--- a/openapi/client.go
+++ b/openapi/client.go
@@ -247,7 +247,17 @@ func parameterToJson(obj interface{}) (string, error) {
 // callAPI do the request.
 func (c *APIClient) callAPI(request *http.Request) (*http.Response, error) {
 	if c.cfg.Debug {
-		dump, err := httputil.DumpRequestOut(request, true)
+		clonedReq := request.Clone(request.Context())
+		if clonedReq.Header.Get("Authorization") != "" {
+			clonedReq.Header.Set("Authorization", "[REDACTED]")
+		}
+		if clonedReq.Header.Get("Proxy-Authorization") != "" {
+			clonedReq.Header.Set("Proxy-Authorization", "[REDACTED]")
+		}
+		if clonedReq.Header.Get("Cookie") != "" {
+			clonedReq.Header.Set("Cookie", "[REDACTED]")
+		}
+		dump, err := httputil.DumpRequestOut(clonedReq, true)
 		if err != nil {
 			return nil, err
 		}

--- a/openapi/model_api_error.go
+++ b/openapi/model_api_error.go
@@ -227,7 +227,6 @@ func (o *APIError) UnmarshalJSON(data []byte) (err error) {
 	varAPIError := _APIError{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varAPIError)
 
 	if err != nil {

--- a/openapi/model_enrich_transaction_collection_response.go
+++ b/openapi/model_enrich_transaction_collection_response.go
@@ -137,7 +137,6 @@ func (o *EnrichTransactionCollectionResponse) UnmarshalJSON(data []byte) (err er
 	varEnrichTransactionCollectionResponse := _EnrichTransactionCollectionResponse{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varEnrichTransactionCollectionResponse)
 
 	if err != nil {

--- a/openapi/model_enrichment_collection_status_response.go
+++ b/openapi/model_enrichment_collection_status_response.go
@@ -108,7 +108,6 @@ func (o *EnrichmentCollectionStatusResponse) UnmarshalJSON(data []byte) (err err
 	varEnrichmentCollectionStatusResponse := _EnrichmentCollectionStatusResponse{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varEnrichmentCollectionStatusResponse)
 
 	if err != nil {

--- a/openapi/model_enrichment_request.go
+++ b/openapi/model_enrichment_request.go
@@ -137,7 +137,6 @@ func (o *EnrichmentRequest) UnmarshalJSON(data []byte) (err error) {
 	varEnrichmentRequest := _EnrichmentRequest{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varEnrichmentRequest)
 
 	if err != nil {

--- a/openapi/model_enrichment_response.go
+++ b/openapi/model_enrichment_response.go
@@ -253,7 +253,6 @@ func (o *EnrichmentResponse) UnmarshalJSON(data []byte) (err error) {
 	varEnrichmentResponse := _EnrichmentResponse{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varEnrichmentResponse)
 
 	if err != nil {

--- a/openapi/model_error_response.go
+++ b/openapi/model_error_response.go
@@ -107,7 +107,6 @@ func (o *ErrorResponse) UnmarshalJSON(data []byte) (err error) {
 	varErrorResponse := _ErrorResponse{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varErrorResponse)
 
 	if err != nil {


### PR DESCRIPTION
## Summary

This PR resolves the enterprise & banking review findings (Tier-1 compliance & audit readiness):

### 🔒 Enterprise Security & Compliance
- **Bearer Token Redaction (C1)**: Redacted `Authorization`, `Proxy-Authorization`, and `Cookie` headers in OpenAPI debug dump logging to prevent API credentials from leaking into application log streams (PCI-DSS Requirements 3 & 10, SOC 2 compliance).
- **Bounded Response Body Reading (C2)**: Enforced a 32 MiB read limit (`io.LimitReader`) on all incoming HTTP response streams to eliminate memory exhaustion / OOM risks from upstream or proxy failures.

### 🛡 API Contract & Forward Compatibility
- **Robustness Principle / Postel's Law (S5)**: Removed `decoder.DisallowUnknownFields()` across all generated models. Additive backend schema evolution (e.g. new JSON fields) will no longer break existing SDK binaries.

### 📖 Documentation & Auditing
- **v2.0.0 Changelog**: Added a comprehensive entry to `CHANGELOG.md` covering all v2 architectural enhancements, RFC 7807 structured error parsing, stream decompression protections, and security measures.

### 🧪 Tests
- Added unit tests for forward-compatible unknown field decoding and verified test suite passes: `go test -v ./...`.