### PR TITLE
feat: add enterprise connection-pooled transport to prevent socket exhaustion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Authorization header cross-host leak prevention on downloads.
 - Automatic secret token redaction in OpenAPI client debug logging (`Authorization`, `Proxy-Authorization`, `Cookie`).
 - Bounded response body reading across all OpenAPI endpoints (`maxResponseBytes = 32MiB`).
+- Enterprise connection-pooled transport (`DefaultEnterpriseTransport` / `NewDefaultHTTPClient`) with `MaxIdleConnsPerHost = 100` to prevent TCP `TIME_WAIT` socket exhaustion under heavy concurrent load.
 - Dedicated SDK version constants in `version.go` (`Version`, `DefaultUserAgent`).
 - Modern Go 1.22 minimum toolchain support across `go.mod`, CI workflows, Docker, and examples.
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ func main() {
 }
 ```
 
-> **Note:** `xyo.Config` is an alias for `xyo.ClientConfig`. You may also configure a custom `BaseURL` (e.g. for staging or mock testing) and a custom `*http.Client` with custom transport or timeout settings.
+> **Note:** `xyo.Config` is an alias for `xyo.ClientConfig`. By default, `NewClient` initializes a production-ready `*http.Client` using `DefaultEnterpriseTransport` (`MaxIdleConnsPerHost = 100`, HTTP/2 enabled) and a 30-second timeout to prevent TCP socket exhaustion under high concurrency. You may also configure a custom `BaseURL` (e.g. for staging or mock testing) and a custom `*http.Client`.
 
 ---
 

--- a/client.go
+++ b/client.go
@@ -2,6 +2,7 @@ package xyo
 
 import (
 	"errors"
+	"net"
 	"net/http"
 	"strings"
 	"time"
@@ -12,6 +13,35 @@ import (
 const defaultAPIBaseURL = "https://api.xyo.financial"
 const defaultTimeout = 30 * time.Second
 
+// DefaultEnterpriseTransport provides a high-throughput, connection-pooled HTTP transport
+// tuned specifically for high-concurrency enterprise microservices.
+//
+// Unlike Go's http.DefaultTransport which restricts MaxIdleConnsPerHost to 2,
+// DefaultEnterpriseTransport allocates up to 100 idle persistent connections per host,
+// preventing TCP TIME_WAIT socket thrashing and ephemeral port exhaustion under heavy load.
+var DefaultEnterpriseTransport = &http.Transport{
+	Proxy: http.ProxyFromEnvironment,
+	DialContext: (&net.Dialer{
+		Timeout:   30 * time.Second,
+		KeepAlive: 30 * time.Second,
+	}).DialContext,
+	ForceAttemptHTTP2:     true,
+	MaxIdleConns:          100,
+	MaxIdleConnsPerHost:   100,
+	IdleConnTimeout:       90 * time.Second,
+	TLSHandshakeTimeout:   10 * time.Second,
+	ExpectContinueTimeout: 1 * time.Second,
+}
+
+// NewDefaultHTTPClient returns a production-ready *http.Client configured with a 30-second
+// timeout and the connection-pooled DefaultEnterpriseTransport.
+func NewDefaultHTTPClient() *http.Client {
+	return &http.Client{
+		Timeout:   defaultTimeout,
+		Transport: DefaultEnterpriseTransport.Clone(),
+	}
+}
+
 // ClientConfig configures the XYO API client.
 type ClientConfig struct {
 	// APIKey is required. Obtain from https://xyo.financial/dashboard
@@ -21,8 +51,8 @@ type ClientConfig struct {
 	// Useful for pointing at staging or a local mock server during testing.
 	BaseURL string
 
-	// HTTPClient overrides the default HTTP client. Leave nil to use a client
-	// with a 30-second timeout — the production-safe default.
+	// HTTPClient overrides the default HTTP client. Leave nil to use NewDefaultHTTPClient()
+	// with a 30-second timeout and enterprise connection pooling.
 	HTTPClient *http.Client
 }
 
@@ -57,9 +87,7 @@ func NewClient(config *ClientConfig) (Client, error) {
 
 	httpCl := config.HTTPClient
 	if httpCl == nil {
-		httpCl = &http.Client{
-			Timeout: defaultTimeout,
-		}
+		httpCl = NewDefaultHTTPClient()
 	}
 
 	cfg := openapi.NewConfiguration()

--- a/enrichment.go
+++ b/enrichment.go
@@ -209,7 +209,7 @@ func (c *client) DownloadEnrichmentCollection(ctx context.Context, downloadURL s
 
 	httpCl := c.apiClient.GetConfig().HTTPClient
 	if httpCl == nil {
-		httpCl = &http.Client{Timeout: defaultTimeout}
+		httpCl = NewDefaultHTTPClient()
 	}
 
 	resp, err := httpCl.Do(req)

--- a/enrichment_test.go
+++ b/enrichment_test.go
@@ -486,3 +486,32 @@ func TestEnrichTransaction_ForwardCompatibilityUnknownFields(t *testing.T) {
 		t.Errorf("expected merchant %q, got %q", "Syniol Limited", resp.Merchant)
 	}
 }
+
+func TestDefaultEnterpriseTransport(t *testing.T) {
+	if DefaultEnterpriseTransport == nil {
+		t.Fatal("expected DefaultEnterpriseTransport to not be nil")
+	}
+	if DefaultEnterpriseTransport.MaxIdleConnsPerHost < 100 {
+		t.Errorf("expected MaxIdleConnsPerHost >= 100, got %d", DefaultEnterpriseTransport.MaxIdleConnsPerHost)
+	}
+	if !DefaultEnterpriseTransport.ForceAttemptHTTP2 {
+		t.Error("expected ForceAttemptHTTP2 to be true")
+	}
+}
+
+func TestNewDefaultHTTPClient(t *testing.T) {
+	client := NewDefaultHTTPClient()
+	if client == nil {
+		t.Fatal("expected NewDefaultHTTPClient to return non-nil client")
+	}
+	if client.Timeout != defaultTimeout {
+		t.Errorf("expected timeout %v, got %v", defaultTimeout, client.Timeout)
+	}
+	tr, ok := client.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("expected transport to be *http.Transport, got %T", client.Transport)
+	}
+	if tr.MaxIdleConnsPerHost < 100 {
+		t.Errorf("expected MaxIdleConnsPerHost >= 100, got %d", tr.MaxIdleConnsPerHost)
+	}
+}


### PR DESCRIPTION
## Summary

This PR addresses the critical scale bottleneck identified for high-throughput enterprise integrations (HSBC, JPMorgan Chase):

### ⚡ Extreme Scale & Connection Pooling
- **DefaultEnterpriseTransport**: Configured a dedicated `*http.Transport` with `MaxIdleConnsPerHost = 100`, `MaxIdleConns = 100`, `ForceAttemptHTTP2 = true`, and keep-alive dialing.
- **Socket Exhaustion Prevention**: Replaces Go's restrictive `http.DefaultTransport` (`MaxIdleConnsPerHost = 2`) default, preventing high-concurrency connection churn, TCP `TIME_WAIT` socket exhaustion, and ephemeral port starvation under heavy microservice workloads.
- **NewDefaultHTTPClient()**: Exposed helper providing a production-tuned `*http.Client` with a 30s timeout and cloned enterprise transport.

### 🧪 Tests & Documentation
- Added unit tests (`TestDefaultEnterpriseTransport`, `TestNewDefaultHTTPClient`) validating transport pool thresholds.
- Updated `README.md` and `CHANGELOG.md`.