### PR TITLE
chore: add client-side input sanity guards and pin generator version

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Generate OpenAPI Go client
         run: |
-          npx -y @openapitools/openapi-generator-cli generate \
+          npx -y @openapitools/openapi-generator-cli@2.13.0 generate \
             -i specs/openapi.yml \
             -g go \
             -o openapi \

--- a/client.go
+++ b/client.go
@@ -91,6 +91,7 @@ func NewClient(config *ClientConfig) (Client, error) {
 	}
 
 	cfg := openapi.NewConfiguration()
+	cfg.Debug = false
 	cfg.UserAgent = DefaultUserAgent
 	cfg.Servers = openapi.ServerConfigurations{
 		{

--- a/enrichment.go
+++ b/enrichment.go
@@ -85,6 +85,12 @@ func (c *client) EnrichTransaction(ctx context.Context, req *EnrichmentRequest) 
 	if req == nil {
 		return nil, fmt.Errorf("xyo: EnrichTransaction: request is nil")
 	}
+	if strings.TrimSpace(req.Content) == "" {
+		return nil, fmt.Errorf("xyo: EnrichTransaction: Content cannot be empty")
+	}
+	if strings.TrimSpace(req.CountryCode) == "" {
+		return nil, fmt.Errorf("xyo: EnrichTransaction: CountryCode cannot be empty")
+	}
 
 	genReq := openapi.NewEnrichmentRequest(req.Content, req.CountryCode)
 	resp, httpResp, err := c.apiClient.EnrichmentAPI.EnrichTransaction(ctx).EnrichmentRequest(*genReq).Execute()
@@ -107,10 +113,20 @@ func (c *client) EnrichTransaction(ctx context.Context, req *EnrichmentRequest) 
 
 // EnrichTransactions submits a bulk enrichment request asynchronously.
 func (c *client) EnrichTransactions(ctx context.Context, reqs []*EnrichmentRequest) (*EnrichTransactionCollectionResponse, error) {
+	if len(reqs) == 0 {
+		return nil, fmt.Errorf("xyo: EnrichTransactions: reqs slice cannot be empty")
+	}
+
 	items := make([]openapi.EnrichTransactionsRequestInner, 0, len(reqs))
 	for i, req := range reqs {
 		if req == nil {
 			return nil, fmt.Errorf("xyo: EnrichTransactions: request at index %d is nil", i)
+		}
+		if strings.TrimSpace(req.Content) == "" {
+			return nil, fmt.Errorf("xyo: EnrichTransactions: request at index %d has empty Content", i)
+		}
+		if strings.TrimSpace(req.CountryCode) == "" {
+			return nil, fmt.Errorf("xyo: EnrichTransactions: request at index %d has empty CountryCode", i)
 		}
 		items = append(items, openapi.EnrichTransactionsRequestInner{
 			Content:     &req.Content,

--- a/enrichment_test.go
+++ b/enrichment_test.go
@@ -515,3 +515,56 @@ func TestNewDefaultHTTPClient(t *testing.T) {
 		t.Errorf("expected MaxIdleConnsPerHost >= 100, got %d", tr.MaxIdleConnsPerHost)
 	}
 }
+
+func TestEnrichTransaction_InputValidation(t *testing.T) {
+	_, client := newTestServerAndClient(t, http.MethodPost, "/v1/ai/finance/enrichment/transaction", http.StatusOK, nil)
+
+	t.Run("empty content", func(t *testing.T) {
+		_, err := client.EnrichTransaction(context.Background(), &EnrichmentRequest{
+			Content:     "   ",
+			CountryCode: "GB",
+		})
+		if err == nil {
+			t.Fatal("expected error for empty content, got nil")
+		}
+	})
+
+	t.Run("empty country code", func(t *testing.T) {
+		_, err := client.EnrichTransaction(context.Background(), &EnrichmentRequest{
+			Content:     "Coffee",
+			CountryCode: "  ",
+		})
+		if err == nil {
+			t.Fatal("expected error for empty country code, got nil")
+		}
+	})
+}
+
+func TestEnrichTransactions_InputValidation(t *testing.T) {
+	_, client := newTestServerAndClient(t, http.MethodPost, "/v1/ai/finance/enrichment/transactions", http.StatusOK, nil)
+
+	t.Run("empty reqs slice", func(t *testing.T) {
+		_, err := client.EnrichTransactions(context.Background(), []*EnrichmentRequest{})
+		if err == nil {
+			t.Fatal("expected error for empty reqs slice, got nil")
+		}
+	})
+
+	t.Run("empty content in slice", func(t *testing.T) {
+		_, err := client.EnrichTransactions(context.Background(), []*EnrichmentRequest{
+			{Content: "", CountryCode: "GB"},
+		})
+		if err == nil {
+			t.Fatal("expected error for empty content in slice, got nil")
+		}
+	})
+
+	t.Run("empty country code in slice", func(t *testing.T) {
+		_, err := client.EnrichTransactions(context.Background(), []*EnrichmentRequest{
+			{Content: "Valid", CountryCode: ""},
+		})
+		if err == nil {
+			t.Fatal("expected error for empty country code in slice, got nil")
+		}
+	})
+}


### PR DESCRIPTION
## Summary

This PR applies the final polish items from the Tier-1 executive architecture review:

### 🛡 Input Validation & Sanity Guards (S2)
- Added non-empty string validation for `req.Content` and `req.CountryCode` in `EnrichTransaction` and `EnrichTransactions`.
- Added empty-slice guard for `reqs` in `EnrichTransactions`.

### 🔒 Supply Chain & Determinism (C2)
- Pinned OpenAPI generator CLI to version `@openapitools/openapi-generator-cli@2.13.0` in `.github/workflows/generate.yml`.

### 🔒 Defense-in-Depth (C3)
- Explicitly set `cfg.Debug = false` by default in `client.go:NewClient`.

### 🧪 Tests
- Added table tests covering empty content, empty country codes, and empty batch slice validation in `enrichment_test.go`.