### PR TITLE
fix(docs): use absolute raw github URL for mascot

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://xyo.financial" target="_blank" rel="noopener noreferrer">
-    <img alt="XYO Financial Go Mascot" width="380" src="docs/mascot.png" />
+    <img alt="XYO Financial Go Mascot" width="380" src="https://raw.githubusercontent.com/xyo-financial/sdk-go/main/docs/mascot.png" />
   </a>
 </p>
 


### PR DESCRIPTION
Ensures the mascot renders on external package registries (pkg.go.dev) and mirrors.